### PR TITLE
Replace lra-coordinator latest with 5.8.2.Final

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 target
 .metadata
 .project
+.settings
+.vscode
+.classpath
+bin

--- a/lra-coordinator.yaml
+++ b/lra-coordinator.yaml
@@ -44,10 +44,10 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/jbosstm/lra-coordinator:latest
+        name: docker.io/jbosstm/lra-coordinator:5.8.2.Final
       generation: 0
       importPolicy: {}
-      name: "latest"
+      name: "5.8.2.Final"
       referencePolicy:
         type: Source
 - apiVersion: v1
@@ -107,5 +107,5 @@ items:
         - lra-coordinator
         from:
           kind: ImageStreamTag
-          name: "lra-coordinator:latest"
+          name: "lra-coordinator:5.8.2.Final"
       type: ImageChange


### PR DESCRIPTION
This is the latest LRA coordinator working image version, at least on:
- oc v3.11.0+0cbc58b
- kubernetes v1.11.0+d4cacc0
